### PR TITLE
fix: move browser to top of exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "types": "./src/lib.d.ts",
   "exports": {
     ".": {
+      "browser": "./src/lib.browser.js",
       "import": "./src/lib.js",
-      "require": "./src/lib.cjs",
-      "browser": "./src/lib.browser.js"
+      "require": "./src/lib.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
The order of exports is important. If you want to serve a browser-specific file, it needs to go earlier in the exports object, otherwise one of the other exports will be matched.

In this case the file being webpacked was using require, which matched `exports.require` before `exports.browser` so tried to require `./src/lib.cjs`, which then throws as it tries to require `util` which is not a dep of this module.

The solution is just to move the `browser` field in front of `require` and `import`.