### PR TITLE
fix: make esm mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,23 +6,22 @@
     "TextEncoder",
     "TextDecoder"
   ],
-  "type": "module",
   "react-native": "./src/lib.react-native.js",
-  "main": "./src/lib.cjs",
-  "module": "./src/lib.js",
-  "browser": "./src/lib.cjs",
+  "main": "./src/lib.js",
+  "module": "./src/lib.mjs",
+  "browser": "./src/lib.js",
   "types": "./src/lib.d.ts",
   "exports": {
     ".": {
-      "import": "./src/lib.js",
-      "require": "./src/lib.cjs"
+      "import": "./src/lib.mjs",
+      "require": "./src/lib.js"
     }
   },
   "scripts": {
-    "test:node": "mocha test/test-*.spec.cjs",
-    "test:browser": "playwright-test test/test-*.cjs",
+    "test:node": "mocha test/test-*.spec.js",
+    "test:browser": "playwright-test test/test-*.js",
     "test:react-native": "jest test/test-lib.react-native.spec.js",
-    "test:es": "mocha test/test-lib.spec.js",
+    "test:es": "mocha test/test-lib.spec.mjs",
     "test:cjs": "npm run test:node && npm run test:browser",
     "test:types:ts": "npm test --prefix test/ts-use",
     "test:types:esm": "npm test --prefix test/esm-use",

--- a/src/lib.cjs
+++ b/src/lib.cjs
@@ -1,7 +1,0 @@
-"use strict"
-
-exports.TextEncoder =
-  typeof TextEncoder !== "undefined" ? TextEncoder : require("util").TextEncoder
-
-exports.TextDecoder =
-  typeof TextDecoder !== "undefined" ? TextDecoder : require("util").TextDecoder

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,7 +1,7 @@
-// In node `export { TextEncoder }` throws:
-// "Export 'TextEncoder' is not defined in module"
-// To workaround we first define constants and then export with as.
-const Encoder = TextEncoder
-const Decoder = TextDecoder
+"use strict"
 
-export { Encoder as TextEncoder, Decoder as TextDecoder }
+exports.TextEncoder =
+  typeof TextEncoder !== "undefined" ? TextEncoder : require("util").TextEncoder
+
+exports.TextDecoder =
+  typeof TextDecoder !== "undefined" ? TextDecoder : require("util").TextDecoder

--- a/src/lib.mjs
+++ b/src/lib.mjs
@@ -1,0 +1,7 @@
+// In node `export { TextEncoder }` throws:
+// "Export 'TextEncoder' is not defined in module"
+// To workaround we first define constants and then export with as.
+const Encoder = TextEncoder
+const Decoder = TextDecoder
+
+export { Encoder as TextEncoder, Decoder as TextDecoder }

--- a/test/test-lib.react-native.spec.js
+++ b/test/test-lib.react-native.spec.js
@@ -1,5 +1,5 @@
-import { TextEncoder, TextDecoder } from "../src/lib.react-native.js"
-import assert from "assert"
+const { TextEncoder, TextDecoder } = require("../src/lib.react-native.js")
+const assert = require("assert")
 
 describe("text encode/decode", () => {
   const data = Uint8Array.from([

--- a/test/test-lib.spec.js
+++ b/test/test-lib.spec.js
@@ -1,5 +1,5 @@
-import { TextEncoder, TextDecoder } from "../src/lib.js"
-import assert from "assert"
+const { TextEncoder, TextDecoder } = require("../src/lib")
+const assert = require("assert")
 
 describe("text encode/decode", () => {
   const data = Uint8Array.from([

--- a/test/test-lib.spec.mjs
+++ b/test/test-lib.spec.mjs
@@ -1,5 +1,5 @@
-const { TextEncoder, TextDecoder } = require("..")
-const assert = require("assert")
+import { TextEncoder, TextDecoder } from "../src/lib.js"
+import assert from "assert"
 
 describe("text encode/decode", () => {
   const data = Uint8Array.from([


### PR DESCRIPTION
Tools such as `create-react-app` require special configuration to handle
`.cjs` as an extension.  Setting `type: "module"` in `package.json` means
we have to use the `.cjs` extension for common js which then breaks these
sorts of tools.

This change removes `type: "module"` and uses the `.js` extension for cjs
files and `.mjs` for esm for maximum compatibiliy.